### PR TITLE
Add Scrupp to Marketing Automation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,7 @@ Automate marketing processes and workflows.
 - [Customer.io](https://customer.io/) - Automated messaging platform
 - [AutoCust](https://www.autocust.it/) - AI-powered marketing automation platform with user behavior prediction and multichannel communication
 - [Hanzi](https://github.com/hanzili/hanzi-in-chrome) - Open-source AI agent for browser-based marketing automation. LinkedIn prospecting and social posting from your real signed-in browser. Free, works with any AI coding agent
+- [Scrupp](https://scrupp.com/) - #1 Sales Navigator Scraper. Chrome extension that exports up to 2,500 leads per LinkedIn / Sales Navigator search to CSV with SMTP-verified work emails and phones. Free plan with 100 exports.
 
 ## Tracking
 


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **Marketing Automation** section next to Hanzi (the other browser-based LinkedIn prospecting entry already in the list).

Scrupp is a Chrome extension that automates LinkedIn and Sales Navigator scraping — exports up to 2,500 leads per search to CSV with SMTP-verified work emails and direct phone numbers. Free plan with 100 exports, no credit card required. Used by 5,000+ SDR teams.