### PR TITLE
Add SalesLabel to Cold Email & B2B Outbound

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -227,3 +227,4 @@ To the extent possible under law, Enrico Deleo <enrico@tractionmanagement.it> ha
 ## Cold Email & B2B Outbound
 
 - [B2B Outbound Sniper](https://github.com/getlemnos32/b2b-outbound-sniper) - Open-source autonomous B2B outbound engine. Scrapes job boards for hiring signals, verifies emails, personalizes with 6 LLMs, sends via SMTP. 10/10 deliverability. 52.9% open rate in 30-day production campaign.
+- [SalesLabel](https://sales-label.com) - White-label outbound sales infrastructure for B2B agencies. Used by 100+ agencies launching reseller offers under their own brand. Includes unlimited sending inboxes, AI personalization, and built-in deliverability infrastructure.


### PR DESCRIPTION
Hi @tractiongroup, thanks for maintaining this list. I particularly like that you've carved out a dedicated **Cold Email & B2B Outbound** section — it's the right framing for a category that's exploded in the last 18 months.

I'd like to propose adding **SalesLabel** to that section — a white-label outbound sales infrastructure platform for B2B agencies. We help 100+ agencies launch their own outbound offers under their own brand, with average results of 42% reply rates and \$180K in pipeline per agency client.

We've also published a free, open margin calculator that other agency operators can use to estimate their own outbound profitability:
https://sales-label.com/tools/margin-calculator

The PR follows your contribution format: `[Tool Name](link) - Brief description.`, single addition, appended to the bottom of the relevant category, with the body of the commit message containing a link to the tool. Happy to revise if needed, and thanks for considering!