### PR TITLE
Add CreatorSkills to Content Marketing section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -97,6 +97,7 @@ Create, manage, and distribute content effectively.
 - [Grammarly](https://www.grammarly.com/) - Writing assistant and grammar checker
 - [CoSchedule](https://coschedule.com/) - Marketing calendar and workflow management
 - [Feedly](https://feedly.com/) - Content curation and RSS reader
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
 
 ## Customer Relationship Management (CRM)
 


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Content Marketing** section.

## Why

CreatorSkills is a marketplace of 30+ downloadable AI skills for content marketers and creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. It works with Claude and ChatGPT, fitting naturally alongside Canva, Grammarly, and other content tools already in this section.

## Checklist

- [x] Link is working and leads to a live site
- [x] Entry follows the existing format
- [x] Placed in the most relevant section (Content Marketing)